### PR TITLE
Fixes display issue with missing or mismatched asset name property for certain assets on historical data

### DIFF
--- a/app/services/yahooService.js
+++ b/app/services/yahooService.js
@@ -106,14 +106,10 @@ function getHistoricalPrices(ticker, options) {
       }
 
       try {
-        var longName = body.split(`"${ticker}":{"sourceInterval"`)[1]
-          .split("longName")[1]
-          .split(":")[1]
-          .split(",")[0].replace(/"/g, '');
-
-        var prices = body.split("HistoricalPriceStore\":{\"prices\"\:")[1].split("}]")[0] + '}]';
-
-        jsonPrices = JSON.parse(prices);
+        var json = getQuoteDataFromBodyAsJson(body)
+        var entity = json[ticker]
+        var longName = (getLongName(entity)) ? getLongName(entity) : getShortName(entity)
+        jsonPrices = getHistoricalDataFromBodyAsJson(body)
 
         const array = jsonPrices.slice((page - 1) * limit, page * limit);
         resolve({ longName, ticker, array });
@@ -127,9 +123,13 @@ function getHistoricalPrices(ticker, options) {
 // Helper functions
 function getQuoteDataFromBodyAsJson(body) {
   const dataStore = body
-                    .split(`"StreamDataStore":`)[1]
-                    .split(`,"QuoteSummaryStore"`)[0];
+    .split(`"StreamDataStore":`)[1]
+    .split(`,"QuoteSummaryStore"`)[0];
   return JSON.parse(dataStore)['quoteData'];
+}
+
+function getHistoricalDataFromBodyAsJson(body) {
+  return JSON.parse(body.split("HistoricalPriceStore\":{\"prices\"\:")[1].split("}]")[0] + '}]');
 }
 
 function getPrice(entity) {


### PR DESCRIPTION
Hi @shweshi, I fixed another display issue on asset names, on calls made to "/historical/{ticker}"

Before:
![image](https://user-images.githubusercontent.com/1536058/200377562-fb983325-79fc-4481-be20-09a0729eff0e.png)

After:
![image](https://user-images.githubusercontent.com/1536058/200377948-b216e4d5-54dc-46f5-87e0-d3559c0ba81e.png)

Cheers,
Christopher